### PR TITLE
Force signOut() to change window location

### DIFF
--- a/lmda/static/src/coffee/all.coffee
+++ b/lmda/static/src/coffee/all.coffee
@@ -74,7 +74,7 @@ signOut = () ->
 
   request.onload = =>
     if request.status == 200
-      setTopbarAuth()
+      window.location = "/"
     else
       console.error(request.responseText)
 


### PR DESCRIPTION
Title. It was just changing any indication of a session (username/menu bar) but leaving you in pages that would normally require auth (api key viewing, uploads list).